### PR TITLE
3 rasterizer results in discontinuous outputs

### DIFF
--- a/main.c
+++ b/main.c
@@ -17,21 +17,6 @@ float userFunc(float x){
     return ans;
 }
 
-float func1(float x){
-    float ans = sinf(x);
-    return ans;
-}
-
-float func2(float x){
-    float ans = 2.0f * cosf(x / 3.0f);
-    return ans;
-}
-
-float func3(float x){
-    float ans = sinf(2.0f * x);
-    return ans;
-}
-
 void printPoints(float * points){
     for (int i = 0; i <= num; i++){
         printf("%f\t%f\n", points[2*i], points[2*i + 1]);
@@ -40,11 +25,10 @@ void printPoints(float * points){
 
 int main(){
     float b[4] = {-10.0f, 10.0f, -4.0f, 4.0f};
-    varsInit(480, 360, 1, 6, 60, b);
+    varsInit(240, 180, 1, 6, 90, b);
     outputInit();
 
     float dx = (float)(bounds[1] - bounds[0]) / (float) num;
-    //printf("%f", dx);
 
 
     // Consider moving this?
@@ -54,26 +38,7 @@ int main(){
     points = (float *) calloc((num+1) * 2, sizeof points);
 
     xPoints(dx, bounds[0], points, userFunc);
-    // PLOT FUNCTIONS ARE PUT HERE
     plot(points);
-
-    changeColor(1);
-    float *points1 = NULL;
-    points1 = (float *) calloc((num+1) * 2, sizeof points1);
-    xPoints(dx, bounds[0], points1, func1);
-    plot(points1);
-
-    changeColor(2);
-    float *points2 = NULL;
-    points2 = (float *) calloc((num+1) * 2, sizeof points1);
-    xPoints(dx, bounds[0], points2, func2);
-    plot(points2);
-
-    changeColor(3);
-    float *points3 = NULL;
-    points3 = (float *) calloc((num+1) * 2, sizeof points1);
-    xPoints(dx, bounds[0], points3, func3);
-    plot(points3);
 
     output("./point.ppm", 0);
     outputCleanup();

--- a/main.c
+++ b/main.c
@@ -18,7 +18,7 @@ float userFunc(float x){
 }
 
 void printPoints(float * points){
-    for (int i = 0; i < num; i++){
+    for (int i = 0; i <= num; i++){
         printf("%f\t%f\n", points[2*i], points[2*i + 1]);
     }
 }
@@ -36,7 +36,7 @@ int main(){
     // Otherwise, it allows easy use of keeping data in an array format, which could be good
     //  for table view and other processing
     float *points = NULL;
-    points = (float *) calloc(num * 2, sizeof points);
+    points = (float *) calloc((num+1) * 2, sizeof points);
 
     xPoints(dx, bounds[0], points, userFunc);
     // PLOT FUNCTIONS ARE PUT HERE

--- a/main.c
+++ b/main.c
@@ -17,6 +17,21 @@ float userFunc(float x){
     return ans;
 }
 
+float func1(float x){
+    float ans = sinf(x);
+    return ans;
+}
+
+float func2(float x){
+    float ans = 2.0f * cosf(x / 3.0f);
+    return ans;
+}
+
+float func3(float x){
+    float ans = sinf(2.0f * x);
+    return ans;
+}
+
 void printPoints(float * points){
     for (int i = 0; i <= num; i++){
         printf("%f\t%f\n", points[2*i], points[2*i + 1]);
@@ -25,7 +40,7 @@ void printPoints(float * points){
 
 int main(){
     float b[4] = {-10.0f, 10.0f, -4.0f, 4.0f};
-    varsInit(240, 180, 1, 1, 64, b);
+    varsInit(480, 360, 1, 6, 60, b);
     outputInit();
 
     float dx = (float)(bounds[1] - bounds[0]) / (float) num;
@@ -40,8 +55,25 @@ int main(){
 
     xPoints(dx, bounds[0], points, userFunc);
     // PLOT FUNCTIONS ARE PUT HERE
-    printPoints(points);
     plot(points);
+
+    changeColor(1);
+    float *points1 = NULL;
+    points1 = (float *) calloc((num+1) * 2, sizeof points1);
+    xPoints(dx, bounds[0], points1, func1);
+    plot(points1);
+
+    changeColor(2);
+    float *points2 = NULL;
+    points2 = (float *) calloc((num+1) * 2, sizeof points1);
+    xPoints(dx, bounds[0], points2, func2);
+    plot(points2);
+
+    changeColor(3);
+    float *points3 = NULL;
+    points3 = (float *) calloc((num+1) * 2, sizeof points1);
+    xPoints(dx, bounds[0], points3, func3);
+    plot(points3);
 
     output("./point.ppm", 0);
     outputCleanup();

--- a/plotters.c
+++ b/plotters.c
@@ -6,7 +6,7 @@
 
 // REQUIRES THE COORDINATES TO BE TRANSFORMED BEFORE USE
 // REQUIRES A REWRITE OF PPMOUTPUT AND OTHER OUTPUT METHODS
-void plotLine(int x0, int y0, int x1, int y1){
+/*void plotLine(int x0, int y0, int x1, int y1){
     int dx = x1 - x0;
     int dy = y1 - y0;
 
@@ -21,7 +21,32 @@ void plotLine(int x0, int y0, int x1, int y1){
         }
         D = D + 2 * dy;
     }
+}*/
+void plotLine(int x0, int y0, int x1, int y1){
+    int dx = abs(x1 - x0);
+    int sx = x0 < x1 ? 1: -1;
+    int dy = -abs(y1 - y0);
+    int sy = y0 < y1 ? 1: -1;
+
+    int error = dx + dy;
+
+    while(1){
+        plotPixel(x0, y0);
+        if(x0 == x1 && y0 == y1){break;}
+        int e2 = 2 * error;
+        if(e2 >= dy){
+            if(x0==x1){break;}
+            error = error + dy;
+            x0 = x0 + sx;
+        }
+        if(e2 <= dx){
+            if(y0 == y1){break;}
+            error = error + dx;
+            y0 = y0 + sy;
+        }
+    }
 }
+
 // This is more of a placeholder because I'm lazy
 void plotPixel(int x, int y){
     // IMPLEMENT SHAPES LATER
@@ -38,7 +63,7 @@ void plot(const float * points){
     float xp1, yp1, xp2, yp2;
     int x0, y0, x1, y1;
 
-    for (unsigned int i = 0; i < (num-1) * 2; i++){
+    for (unsigned int i = 0; i < num; i++){
         xp1 = points[2*i];
         yp1 = points[2*i + 1];
         xp2 = points[2*(i+1)];

--- a/plotters.c
+++ b/plotters.c
@@ -50,7 +50,7 @@ void plotLine(int x0, int y0, int x1, int y1){
 // This is more of a placeholder because I'm lazy
 void plotPixel(int x, int y){
     // IMPLEMENT SHAPES LATER
-    if (x < 0 | x > xRes | y < 0 | y > yRes){
+    if (x < 0 | x >= xRes | y < 0 | y >= yRes){
         return;
     }
     img[xRes * y + x] = lineColor;

--- a/pointGenerators.c
+++ b/pointGenerators.c
@@ -11,7 +11,7 @@ void xPoints(
         float f(float)
         ){
 
-    for (unsigned int i = 0; i < num; i++){
+    for (unsigned int i = 0; i <= num; i++){
         points[2*i] = x;
         points[2*i + 1] = f(x);
         x += dx;


### PR DESCRIPTION
Fix #3. Error was due to poor understanding of rasterization algorithm, algorithm was only implemented to support positive slopes between 0 and 1. Has been resolved and supports any real slope.

Return-to-origin error fixed, was caused by faulty indexing and memory allocation.

Wrap-around error fixed, out-of-bounds checker wasn't accounting for coordinates being zero-indexed.